### PR TITLE
Fix missing plugin-error module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "jshint": "^2.13.6",
         "mocha": "^10.2.0",
         "nodemon": "^3.0.1",
+        "plugin-error": "^2.0.1",
         "sat": "^0.9.0",
         "socket.io": "^4.6.1",
         "socket.io-client": "^4.6.1",
@@ -34,8 +35,7 @@
         "webpack-stream": "^7.0.0"
       },
       "devDependencies": {
-        "@types/sat": "^0.0.32",
-        "plugin-error": "^2.0.1"
+        "@types/sat": "^0.0.32"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -10425,7 +10425,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-2.0.1.tgz",
       "integrity": "sha512-zMakqvIDyY40xHOvzXka0kUvf40nYIuwRE8dWhti2WtjQZ31xAgBZBhxsK7vK3QbRXS1Xms/LO7B5cuAsfB2Gg==",
-      "dev": true,
       "dependencies": {
         "ansi-colors": "^1.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -61,10 +61,10 @@
     "sqlite3": "^5.1.6",
     "uuid": "^9.0.0",
     "webpack": "^5.82.1",
-    "webpack-stream": "^7.0.0"
+    "webpack-stream": "^7.0.0",
+    "plugin-error": "^2.0.1"
   },
   "devDependencies": {
-    "@types/sat": "^0.0.32",
-    "plugin-error": "^2.0.1"
+    "@types/sat": "^0.0.32"
   }
 }


### PR DESCRIPTION
## Summary
- move `plugin-error` to dependencies so Gulp can run in production

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687abbc836a08320b3a2aed44cd1495c